### PR TITLE
Non-atomic CSV import view so import task can always safely fetch task object

### DIFF
--- a/smartmin/csv_imports/tasks.py
+++ b/smartmin/csv_imports/tasks.py
@@ -1,11 +1,8 @@
 from __future__ import unicode_literals
 
-import django
-
 from celery.task import task
-from distutils.version import StrictVersion
+from django.db import transaction
 from django.utils import timezone
-from time import sleep
 from smartmin import class_from_string
 from .models import ImportTask
 
@@ -18,38 +15,16 @@ except ImportError:
 
 @task(track_started=True)
 def csv_import(task_id):  # pragma: no cover
-    from django.db import transaction
-
-    # there is a possible race condition between this task starting
-    # so we have a bit of loop here to fetch the task
-    tries = 0
-    task = None
-    while tries < 5 and not task:
-        try:
-            task = ImportTask.objects.get(pk=task_id)
-        except Exception as e:
-            # this object just doesn't exist yet, sleep a bit then try again
-            tries+=1
-            if tries >= 5:
-                raise e
-            else:
-                sleep(1)
-
+    task = ImportTask.objects.get(pk=task_id)
     log = StringIO()
 
-    if StrictVersion(django.get_version()) < StrictVersion('1.6'):
+    task.task_id = csv_import.request.id
+    task.log("Started import at %s" % timezone.now())
+    task.log("--------------------------------")
+    task.save()
 
-        transaction.enter_transaction_management()
-        transaction.managed()
-
-        try:
-            task.task_id = csv_import.request.id
-            task.log("Started import at %s" % timezone.now())
-            task.log("--------------------------------")
-            task.save()
-
-            transaction.commit()
-
+    try:
+        with transaction.atomic():
             model = class_from_string(task.model_class)
             records = model.import_csv(task, log)
             task.save()
@@ -58,47 +33,13 @@ def csv_import(task_id):  # pragma: no cover
             task.log("Import finished at %s" % timezone.now())
             task.log("%d record(s) added." % len(records))
 
-            transaction.commit()
+    except Exception as e:
+        import traceback
+        traceback.print_exc(e)
 
-        except Exception as e:
-            transaction.rollback()
+        task.log("\nError: %s\n" % e)
+        task.log(log.getvalue())
 
-            import traceback
-            traceback.print_exc(e)
-
-            task.log("\nError: %s\n" % e)
-            task.log(log.getvalue())
-            transaction.commit()
-
-            raise e
-
-        finally:
-            transaction.leave_transaction_management()
-
-    else:
-
-        task.task_id = csv_import.request.id
-        task.log("Started import at %s" % timezone.now())
-        task.log("--------------------------------")
-        task.save()
-
-        try:
-            with transaction.atomic():
-                model = class_from_string(task.model_class)
-                records = model.import_csv(task, log)
-                task.save()
-
-                task.log(log.getvalue())
-                task.log("Import finished at %s" % timezone.now())
-                task.log("%d record(s) added." % len(records))
-
-        except Exception as e:
-            import traceback
-            traceback.print_exc(e)
-
-            task.log("\nError: %s\n" % e)
-            task.log(log.getvalue())
-
-            raise e
+        raise e
 
     return task

--- a/smartmin/mixins.py
+++ b/smartmin/mixins.py
@@ -1,9 +1,26 @@
 from __future__ import unicode_literals
+"""
+simple mixins that keep you from writing so much code
+"""
+
+from django.db import transaction
+from django.utils.decorators import method_decorator
 
 
-# simple mixins that keep you from writing so much code
 class PassRequestToFormMixin(object):
+    """
+    Mixin to include the request in the form kwargs
+    """
     def get_form_kwargs(self):
         kwargs = super(PassRequestToFormMixin, self).get_form_kwargs()
         kwargs['request'] = self.request
         return kwargs
+
+
+class NonAtomicMixin(object):
+    """
+    Mixin to configure a view to be handled without a transaction
+    """
+    @method_decorator(transaction.non_atomic_requests)
+    def dispatch(self, request, *args, **kwargs):
+        return super(NonAtomicMixin, self).dispatch(request, *args, **kwargs)

--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -23,6 +23,7 @@ from django.views.generic import DetailView, ListView
 from guardian.shortcuts import get_objects_for_user, assign_perm
 from guardian.utils import get_anonymous_user
 from smartmin.csv_imports.models import ImportTask
+from smartmin.mixins import NonAtomicMixin
 from . import widgets
 
 
@@ -1290,7 +1291,7 @@ class SmartCreateView(SmartModelFormView, CreateView):
             return self.title
 
 
-class SmartCSVImportView(SmartCreateView):
+class SmartCSVImportView(NonAtomicMixin, SmartCreateView):
     success_url = 'id@csv_imports.importtask_read'
 
     fields = ('csv_file',)


### PR DESCRIPTION
Also removed old Django 1.5 transaction support since smartmin currently requires Django 1.7+