### PR TITLE
Fix fields bound to empty related fields being ignored

### DIFF
--- a/smartmin/templates/smartmin/field.html
+++ b/smartmin/templates/smartmin/field.html
@@ -6,7 +6,7 @@
 {% if form_field and form_field.is_hidden %}
 {{ form_field }}
 {% else %}
-{% if form_field %}
+{% if form_field != None %}
 <div class="form-group {% if form_field.errors %}error{% endif %}">
   <label class="col-sm-2 control-label" for="{{ field.name }}">{% get_label field %}</label>
   <div class="col-sm-10 smartmin-form-field">

--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -141,10 +141,6 @@ class SmartView(object):
         # next up is the object itself
         obj_field = getattr(obj, curr_field, None)
 
-        # if it is callable, do so
-        if obj_field and getattr(obj_field, '__call__', None):
-            obj_field = obj_field()
-
         if obj_field and rest:
             return self.lookup_obj_attribute(obj_field, rest)
         else:

--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -141,6 +141,10 @@ class SmartView(object):
         # next up is the object itself
         obj_field = getattr(obj, curr_field, None)
 
+        # if it is callable, do so
+        if obj_field and getattr(obj_field, '__call__', None):
+            obj_field = obj_field()
+
         if obj_field and rest:
             return self.lookup_obj_attribute(obj_field, rest)
         else:


### PR DESCRIPTION
If a form field is bound to related field on a model which is empty - it ends up being evaluated as falsey and ignored in our field template.

Then in addition because related fields have a __call__ method, we try to call them and things blow up, e.g. https://sentry.io/nyaruka/casepro/issues/288024834/