### PR TITLE
Don't blow up if querystring contains a param with an empty name

### DIFF
--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -322,7 +322,7 @@ class SmartView(object):
         url_params = "?"
         order_params = ""
         for key in self.request.GET.keys():
-            if key != 'page' and key != 'pjax' and key[0] != '_':
+            if key != 'page' and key != 'pjax' and (len(key) == 0 or key[0] != '_'):
                 for value in self.request.GET.getlist(key):
                     url_params += "%s=%s&" % (key, urlquote(value))
             elif key == '_order':

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -242,6 +242,12 @@ class PostTest(SmartminTest):
                 {'id': self.post.id, 'text': 'Test Post'}
             ], 'err': 'nil', 'more': False})
 
+        # check parsing of query string params used for paging URLs
+        response = self.client.get(reverse('blog.post_list') + "?=x&foo=bar&_order=-title&page=1")
+        self.assertEqual(list(response.context['post_list']), [self.post, post3, post2, post4, post1])
+        self.assertEqual(response.context['url_params'], '?=x&foo=bar&')
+        self.assertEqual(response.context['order_params'], '_order=-title&')
+
     def test_success_url(self):
         self.client.login(username='author', password='author')
 


### PR DESCRIPTION
E.g. https://sentry.io/nyaruka/textit/issues/302214696/