### PR TITLE
Use new method to avoid deprecation warning of pypandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 
 try:
-    from pypandoc import convert
-    read_md = lambda f: convert(f, 'rst')  # noqa
+    from pypandoc import convert_file
+    read_md = lambda f: convert_file(f, 'rst')  # noqa
 except ImportError:
     print("warning: pypandoc module not found, could not convert Markdown to RST")
     read_md = lambda f: open(f, 'r').read()  # noqa


### PR DESCRIPTION
`DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.`