### PR TITLE
Fix import file_path generation

### DIFF
--- a/smartmin/csv_imports/models.py
+++ b/smartmin/csv_imports/models.py
@@ -8,11 +8,15 @@ from smartmin.models import SmartModel
 
 
 def generate_file_path(instance, filename):
-    name, extension = os.path.splitext(filename)
-    if len(name) + len(extension) >= 100:
-        name = name[:100-len(extension)]
 
-    return "csv_imports/%s%s" % (name, extension)
+    file_path_prefix = 'csv_imports/'
+
+    name, extension = os.path.splitext(filename)
+
+    if len(name) + len(extension) >= 100:
+        name = name[:100-len(extension)-len(file_path_prefix)]
+
+    return "%s%s%s" % (file_path_prefix, name, extension)
 
 
 class ImportTask(SmartModel):

--- a/smartmin/csv_imports/tests.py
+++ b/smartmin/csv_imports/tests.py
@@ -13,8 +13,11 @@ class ImportTest(TestCase):
         self.assertEquals(generate_file_path(ImportTask(), 'allo.foo.bar'), 'csv_imports/allo.foo.bar')
 
         long_name = 'foo' * 100
-        self.assertEquals(generate_file_path(ImportTask(), '%s.xls.csv' % long_name),
-                          'csv_imports/%s.csv' % long_name[:96])
 
-        self.assertEquals(generate_file_path(ImportTask(), '%s.abc.xlsx' % long_name),
-                          'csv_imports/%s.xlsx' % long_name[:95])
+        test_file_name = '%s.xls.csv' % long_name
+        self.assertEquals(len(generate_file_path(ImportTask(), test_file_name)), 100)
+        self.assertEquals(generate_file_path(ImportTask(), test_file_name), 'csv_imports/%s.csv' % long_name[:84])
+
+        test_file_name = '%s.abc.xlsx' % long_name
+        self.assertEquals(len(generate_file_path(ImportTask(), test_file_name)), 100)
+        self.assertEquals(generate_file_path(ImportTask(), test_file_name), 'csv_imports/%s.xlsx' % long_name[:83])


### PR DESCRIPTION
Fixes: https://sentry.io/nyaruka/rapidpro/issues/701555086/

This fix includes the file_path_prefix length when truncating the file
name.