### PR TITLE
open candidate csv files in mode that deals with BoM

### DIFF
--- a/smartmin/models.py
+++ b/smartmin/models.py
@@ -300,7 +300,7 @@ class SmartModel(models.Model):
                 break
         reader.close()
 
-        reader = open(filename.name, "rU")
+        reader = open(filename.name, "rU", encoding='utf-8-sig')
 
         def unicode_csv_reader(utf8_data, dialect=csv.excel, **kwargs):
             csv_reader = csv.reader(utf8_data, dialect=dialect, **kwargs)

--- a/smartmin/models.py
+++ b/smartmin/models.py
@@ -104,7 +104,7 @@ class SmartModel(models.Model):
                     break
             reader.close()
 
-            reader = open(filename.name, "rU")
+            reader = open(filename.name, "rU", encoding='utf-8-sig')
 
             def unicode_csv_reader(utf8_data, dialect=csv.excel, **kwargs):
                 csv_reader = csv.reader(utf8_data, dialect=dialect, **kwargs)

--- a/test_runner/blog/test_files/bom_import.csv
+++ b/test_runner/blog/test_files/bom_import.csv
@@ -1,0 +1,2 @@
+﻿URN:tel,Name,Field:email-address
+12065551212,Fred,fred@gmail.com

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -463,6 +463,9 @@ class PostTest(SmartminTest):
         with open('test_runner/blog/test_files/posts.csv', 'rb') as open_file:
             self.assertEqual(Post.get_import_file_headers(open_file), ['title', 'body', 'order', 'tags'])
 
+        with open('test_runner/blog/test_files/bom_import.csv', 'rb') as open_file:
+            self.assertEqual(Post.get_import_file_headers(open_file), ['URN:tel', 'Name', 'Field:email-address'])
+
     def test_csv_import(self):
         with self.settings(CELERY_ALWAYS_EAGER=True, CELERY_RESULT_BACKEND='cache', CELERY_CACHE_BACKEND='memory'):
             import_url = reverse('blog.post_csv_import')

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -464,7 +464,7 @@ class PostTest(SmartminTest):
             self.assertEqual(Post.get_import_file_headers(open_file), ['title', 'body', 'order', 'tags'])
 
         with open('test_runner/blog/test_files/bom_import.csv', 'rb') as open_file:
-            self.assertEqual(Post.get_import_file_headers(open_file), ['URN:tel', 'Name', 'Field:email-address'])
+            self.assertEqual(Post.get_import_file_headers(open_file), ['urn:tel', 'name', 'field:email-address'])
 
     def test_csv_import(self):
         with self.settings(CELERY_ALWAYS_EAGER=True, CELERY_RESULT_BACKEND='cache', CELERY_CACHE_BACKEND='memory'):


### PR DESCRIPTION
See: https://stackoverflow.com/questions/17912307/u-ufeff-in-python-string

Without this we fail opening files that contain BoM markers as we view the headers as invalid.