### PR TITLE
Fix XSS in url parameter keys

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 celery
-django>=2.1,<3.0
+django>=2.2.10,<3.0
 django_compressor
 pytz
 redis

--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -325,7 +325,7 @@ class SmartView(object):
         for key in self.request.GET.keys():
             if key != 'page' and key != 'pjax' and (len(key) == 0 or key[0] != '_'):
                 for value in self.request.GET.getlist(key):
-                    url_params += "%s=%s&" % (key, urlquote(value))
+                    url_params += "%s=%s&" % (urlquote(key), urlquote(value))
             elif key == '_order':
                 order_params = "&".join(["%s=%s" % (key, _) for _ in self.request.GET.getlist(key)])
 

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -266,6 +266,10 @@ class PostTest(SmartminTest):
         self.assertEqual(response.context['url_params'], '?=x&foo=bar&')
         self.assertEqual(response.context['order_params'], '_order=-title&')
 
+        # check escaping of keys and values in params
+        response = self.client.get(reverse('blog.post_list') + "?\"<alert>=<alert>")
+        self.assertEqual(response.context['url_params'], '?%22%3Calert%3E=%3Calert%3E&')
+
     def test_list_no_pagination(self):
         post1 = Post.objects.create(title="A First Post", body="Apples", order=3, tags="post",
                                     created_by=self.author, modified_by=self.author)


### PR DESCRIPTION
Though we were quoting the values, we also need to quote the values to prevent possible XSS when `url_params` in used in pjax etc..