### PR TITLE
Ignore `_format=json` on views that don't support it

### DIFF
--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -49,7 +49,7 @@ def smart_url(url, obj=None):
             return url % obj.id
 
 
-class SmartView(object):
+class SmartView:
     fields = None
     exclude = None
     field_config = {}
@@ -368,19 +368,21 @@ class SmartView(object):
         Responsible for turning our context into an dict that can then be serialized into an
         JSON response.
         """
-        return context
+        raise NotImplementedError("this view can't be rendered as JSON")
 
     def render_to_response(self, context, **response_kwargs):
         """
         Overloaded to deal with _format arguments.
         """
-        # should we actually render in json?
+        # should we try rendering as JSON?
         if '_format' in self.request.GET and self.request.GET['_format'] == 'json':
-            return JsonResponse(self.as_json(context), safe=False)
+            try:
+                return JsonResponse(self.as_json(context), safe=False)
+            except NotImplementedError:
+                pass
 
         # otherwise, return normally
-        else:
-            return super(SmartView, self).render_to_response(context)
+        return super(SmartView, self).render_to_response(context)
 
 
 class SmartTemplateView(SmartView, TemplateView):

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -199,6 +199,21 @@ class PostTest(SmartminTest):
         response = self.client.get(reverse('blog.post_list'))
         self.assertEquals(['blog/post_list.html', 'smartmin/list.html'], response.template_name)
 
+    def test_read(self):
+        post = Post.objects.create(title="A First Post", body="Apples", order=3, tags="post",
+                                    created_by=self.author, modified_by=self.author)
+
+        read_url = reverse('blog.post_read', args=[post.id])
+
+        response = self.client.get(read_url)
+        self.assertEqual(post, response.context['object'])
+        self.assertContains(response, '<td class="read-label">Title</td>')
+        self.assertContains(response, '<td class="read-value">A First Post&nbsp;</td>')
+
+        # because this view doesn't override as_json, _format=json is ignored
+        response = self.client.get(read_url + "?_format=json")
+        self.assertContains(response, "<title>Smartmin</title>")
+
     def test_list(self):
         post1 = Post.objects.create(title="A First Post", body="Apples", order=3, tags="post",
                                     created_by=self.author, modified_by=self.author)

--- a/test_runner/blog/views.py
+++ b/test_runner/blog/views.py
@@ -55,13 +55,7 @@ class PostCRUDL(SmartCRUDL):
         default_order = 'title'
 
         def as_json(self, context):
-            items = []
-            for obj in self.object_list:
-                items.append(dict(title=obj.title,
-                                  body=obj.body,
-                                  tags=obj.tags))
-
-            return items
+            return [{"title": obj.title, "body": obj.body, "tags": obj.tags} for obj in self.object_list]
 
     class ListNoPagination(SmartListView):
         fields = ('title', 'tags', 'created_on', 'created_by')
@@ -71,13 +65,7 @@ class PostCRUDL(SmartCRUDL):
         paginate_by = None
 
         def as_json(self, context):
-            items = []
-            for obj in self.object_list:
-                items.append(dict(title=obj.title,
-                                  body=obj.body,
-                                  tags=obj.tags))
-
-            return items
+            return [{"title": obj.title, "body": obj.body, "tags": obj.tags} for obj in self.object_list]
 
     class Author(SmartListView):
         fields = ('title', 'tags', 'created_on', 'created_by')


### PR DESCRIPTION
Replace the default `SmartView.as_json` implementation with a `NotImplementedError` as it can never work