### PR TITLE
Prevent mimicking of superusers and staff users

### DIFF
--- a/smartmin/templates/smartmin/users/user_update.html
+++ b/smartmin/templates/smartmin/users/user_update.html
@@ -2,7 +2,7 @@
 {% load smartmin %}
 
 {% block post-form %}
-{% if perms.auth.user_mimic %}
+{% if perms.auth.user_mimic and not object.is_superuser and not object.is_staff %}
 <form class="smartmin-form form-horizontal" action="{% url 'users.user_mimic' object.id %}" method="post" enctype="multipart/form-data">
   {% csrf_token %}
   <div class="form-group">

--- a/smartmin/users/views.py
+++ b/smartmin/users/views.py
@@ -394,6 +394,10 @@ class UserCRUDL(SmartCRUDL):
     class Mimic(SmartUpdateView):
         fields = ("id",)
 
+        def derive_queryset(self):
+            # don't allow mimicking of superusers or staff as that would allow privilege escalation
+            return super().derive_queryset().exclude(is_staff=True).exclude(is_superuser=True)
+
         def derive_success_message(self):
             return _("You are now logged in as %s") % self.object.username
 

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -713,6 +713,42 @@ class UserTest(TestCase):
         self.assertTrue("form" in response.context)
         self.assertTrue(response.context["form"].errors)
 
+    def test_mimic_protected_users(self):
+        self.client.login(username="superuser", password="superuser")
+
+        # regular users can be mimicked
+        steve = User.objects.create_user("steve", "steve@group.com", "steve")
+        response = self.client.post(reverse("users.user_mimic", args=[steve.id]), follow=True)
+        self.assertEqual(response.context["user"].username, "steve")
+
+        # mimicking steve left us logged in as steve, so log back in as the superuser
+        self.client.logout()
+        self.client.login(username="superuser", password="superuser")
+
+        # but superusers and staff can't be mimicked
+        other_superuser = User.objects.create_user("otheradmin", "other@group.com", "otheradmin")
+        other_superuser.is_superuser = True
+        other_superuser.save()
+
+        staff = User.objects.create_user("staff", "staff@group.com", "staff")
+        staff.is_staff = True
+        staff.save()
+
+        response = self.client.post(reverse("users.user_mimic", args=[other_superuser.id]))
+        self.assertEqual(404, response.status_code)
+        self.assertEqual("superuser", response.wsgi_request.user.username)
+
+        response = self.client.post(reverse("users.user_mimic", args=[staff.id]))
+        self.assertEqual(404, response.status_code)
+        self.assertEqual("superuser", response.wsgi_request.user.username)
+
+        # and their edit pages don't offer the mimic button
+        response = self.client.get(reverse("users.user_update", args=[steve.id]))
+        self.assertContains(response, "Login as")
+
+        response = self.client.get(reverse("users.user_update", args=[other_superuser.id]))
+        self.assertNotContains(response, "Login as")
+
     def test_crudl(self):
         self.client.login(username="superuser", password="superuser")
 


### PR DESCRIPTION
The mimic view logs the requesting user in as the target user, so allowing superuser or staff targets meant anyone granted the mimic permission could escalate to superuser.

Superuser and staff targets now return a 404 before any session change, and the "Login as" button is hidden on their edit pages so the UI matches the rule.

Adds regression tests, including asserting the operator's session is unchanged after a blocked attempt.