### PR TITLE
Fix column sorting detection in list views

### DIFF
--- a/smartmin/views.py
+++ b/smartmin/views.py
@@ -7,7 +7,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db import IntegrityError
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
@@ -560,14 +560,14 @@ class SmartListView(SmartView, ListView):
 
     def lookup_field_orderable(self, field):
         """
-        Returns whether the passed in field is sortable or not, by default all 'raw' fields, that
-        is fields that are part of the model are sortable.
+        Returns whether the passed in field is sortable or not, by default all concrete model fields
+        are sortable (i.e. not computed fields, m2ms or reverse relations which would require joins).
         """
+        model = self.model if self.model else self.object_list.model
+
         try:
-            self.model._meta.get_field_by_name(field)
-            return True
-        except Exception:
-            # that field doesn't exist, so not sortable
+            return model._meta.get_field(field).concrete
+        except FieldDoesNotExist:
             return False
 
     def get_context_data(self, **kwargs):

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -25,7 +25,7 @@ from smartmin.views import smart_url
 from smartmin.widgets import DatePickerWidget, ImageThumbnailWidget
 from test_runner.blog.models import Category, Post
 
-from .views import PostCRUDL
+from .views import PostCRUDL, UserCRUDL
 
 
 class PostTest(SmartminTest):
@@ -266,6 +266,20 @@ class PostTest(SmartminTest):
         # default ordering is by title
         response = self.client.get(reverse("blog.post_list"))
         self.assertEqual(list(response.context["post_list"]), [post1, post4, post2, post3, self.post])
+
+        # concrete model fields are orderable, non-fields are not
+        view = response.context["view"]
+        self.assertTrue(view.lookup_field_orderable("title"))
+        self.assertTrue(view.lookup_field_orderable("created_by"))
+        self.assertFalse(view.lookup_field_orderable("not_a_field"))
+
+        # and orderable columns render as sortable headers
+        self.assertContains(response, "header-title header")
+
+        # m2m fields aren't orderable as they would require joins that duplicate rows
+        user_list = UserCRUDL().view_for_action("list")()
+        self.assertFalse(user_list.lookup_field_orderable("groups"))
+        self.assertTrue(user_list.lookup_field_orderable("username"))
 
         # try ordering by title reversed
         response = self.client.get(reverse("blog.post_list") + "?_order=-title")


### PR DESCRIPTION
`SmartListView.lookup_field_orderable` still called `Meta.get_field_by_name`, which was removed in Django 1.10, and the broad `except` swallowed the error — so no list column has rendered as sortable in years.

Now uses `_meta.get_field` and treats only concrete fields as orderable, so m2m and reverse relations can't introduce row-duplicating joins now that headers are clickable again. Also handles list views configured with a queryset but no `model`.

Adds tests for concrete fields, m2m fields, non-fields, and the rendered sortable header.