### PR TITLE
Fix TimezoneMiddleware to activate timezone before the view runs

### DIFF
--- a/smartmin/middleware.py
+++ b/smartmin/middleware.py
@@ -7,11 +7,11 @@ class TimezoneMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        response = self.get_response(request)
-
         user_tz = getattr(settings, "USER_TIME_ZONE", None)
 
         if user_tz:
             timezone.activate(user_tz)
+        else:
+            timezone.deactivate()
 
-        return response
+        return self.get_response(request)

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -1160,7 +1160,10 @@ class TagTestCase(TestCase):
         context = dict(view=self.read_view, object=self.post)
         self.assertEqual(self.post.title, get_value_from_view(context, "title"))
         local_created = self.post.created_on.replace(tzinfo=tzone.utc).astimezone(ZoneInfo("Africa/Kigali"))
-        self.assertEqual(local_created.strftime("%b %d, %Y %H:%M"), get_value_from_view(context, "created_on"))
+
+        # aware values are rendered in the active timezone
+        with timezone.override("Africa/Kigali"):
+            self.assertEqual(local_created.strftime("%b %d, %Y %H:%M"), get_value_from_view(context, "created_on"))
 
     def test_view_as_json(self):
         self.list_view.object_list = Post.objects.all()
@@ -1186,10 +1189,11 @@ class TagTestCase(TestCase):
     def test_gmail_time(self):
         from smartmin.templatetags.smartmin import gmail_time
 
-        # given the time as now, should display "Hour:Minutes AM|PM" eg. "5:05 pm"
+        # given the time as now, should display "Hour:Minutes AM|PM" in the active timezone, eg. "5:05 pm"
         now = timezone.now()
         modified_now = now.replace(hour=17, minute=5)
-        self.assertEqual("7:05 pm", gmail_time(modified_now))
+        with timezone.override("Africa/Kigali"):
+            self.assertEqual("7:05 pm", gmail_time(modified_now))
 
         # given the time beyond 12 hours ago within the same month, should display "MonthName DayOfMonth" eg. "Jan 2"
         now = now.replace(day=3, month=3, hour=10)


### PR DESCRIPTION
`TimezoneMiddleware` activated the timezone after the response had already been generated, so it had no effect on the current request and instead leaked thread-local state into whatever request that thread handled next.

It now activates before calling `get_response`, and deactivates when no user timezone is configured so stale state from other code can't linger.

Also fixes two template tag tests that were unknowingly depending on the leaked activation and failed when run in isolation — they now set the timezone explicitly with `timezone.override`.

Note for deployers: with the middleware working as intended, aware datetimes render in `USER_TIME_ZONE` during requests where previously they used `TIME_ZONE`.