### PR TITLE
Fix ImageThumbnailWidget rendering a duplicate width attribute instead of height

### DIFF
--- a/smartmin/widgets.py
+++ b/smartmin/widgets.py
@@ -51,7 +51,7 @@ class ImageThumbnailWidget(widgets.ClearableFileInput):
             except ImportError:
                 pass
 
-            thumb_html += '<td><img src="%s" width="%s" width="%s" /></td>' % (value.url, self.width, self.height)
+            thumb_html += '<td><img src="%s" width="%s" height="%s" /></td>' % (value.url, self.width, self.height)
 
         thumb_html += '<td><input type="checkbox" name="%s-clear" /> Clear' % name
         thumb_html += '<input type="file" name="%s" /></td>' % name

--- a/test_runner/blog/tests.py
+++ b/test_runner/blog/tests.py
@@ -1457,7 +1457,7 @@ class WidgetsTest(SmartminTest):
         img.url = "/media/2423.jpg"
         html = widget.render("logo", img)
 
-        self.assertIn('<img src="/media/2423.jpg" width="320" width="240" />', html)
+        self.assertIn('<img src="/media/2423.jpg" width="320" height="240" />', html)
 
 
 class IsPasswordComplexTest(TestCase):


### PR DESCRIPTION
The thumbnail image tag was rendered with two `width` attributes, so the configured thumbnail height was never applied. The second attribute is now `height`. Updates the existing widget test, which was asserting the buggy markup.