### PR TITLE
Remove pdb template tag

### DIFF
--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -38,15 +38,3 @@ If you want to enable this, you'll just need to add ``compressor`` to your ``INS
   )
 
 And change the commented out ``{# compress #}`` tags in ``base.html`` to be valid, ie: ``{% compress %}``.
-
-
-PDB Template Tag
-----------------
-
-We all love ``pdb.set_trace()`` to help us debug problems, but sometimes you want to do the same thing in a template.
-The smartmin template tags include just that::
-
-   {% pdb %}
-
-Will throw you into a pdb session when it hits that tag.  You can examine variables in the session (including the
-request) and debug your template live.

--- a/smartmin/templatetags/smartmin.py
+++ b/smartmin/templatetags/smartmin.py
@@ -230,22 +230,6 @@ def field_orderable(view, field):
     return view.lookup_field_orderable(field)
 
 
-class PDBNode(template.Node):
-    """
-    Woot woot, simple pdb debugging. {% pdb %}
-    """
-
-    def render(self, context):
-        import pdb
-
-        pdb.set_trace()  # noqa
-
-
-@register.tag
-def pdb(parser, token):
-    return PDBNode()
-
-
 @register.simple_tag(takes_context=True)
 def getblock(context, prefix, suffix=None):
     key = prefix


### PR DESCRIPTION
Removes the `{% pdb %}` template tag — a debugger breakpoint at template render time is a worker-hanging hazard for a library to ship if it ever reaches production. Also removes the docs section that taught the tag.